### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ wsm.subscribe(name, channel="ticker", op="subscribe", market="BTC/USDT")
 
 # Auth subscribe
 name = 'private_connection'
-wsm.start_socket(on_read, conn_name=name)
+wsm.start_socket(on_read, socket_name=name)
 wsm.login(conn_name=name)
 wsm.subscribe(
     name,


### PR DESCRIPTION
`start_socket` method has no argument `conn_name`.